### PR TITLE
Http parser strings to streams

### DIFF
--- a/src/http/parser.lisp
+++ b/src/http/parser.lisp
@@ -55,7 +55,7 @@ When the machine arrives in the `:done' state the `http-method', `resource' and
   (:default-initargs . (:state :key-or-done)))
 
 (defmethod initialize-instance :after ((fsm header-fsm) &key)
-  "Rest the key- and value- buffers to fresh string output streams"
+  "Reset the key- and value- buffers to fresh string output streams"
   (setf (key-buffer fsm) (make-string-output-stream)
         (value-buffer fsm) (make-string-output-stream)))
 

--- a/src/http/parser.lisp
+++ b/src/http/parser.lisp
@@ -3,10 +3,13 @@
 ;; HTTP Parser
 ;;; Request line parser
 (deffsm request-fsm ()
-  ((http-method :initform (string "") :accessor http-method)
-   (resource :initform (string "") :accessor resource)
-   (version :initform (string "") :accessor version))
-  (:default-initargs . (:state :read-http-method)))
+  ((http-method :initform (make-string-output-stream) :accessor http-method)
+   (resource :initform (make-string-output-stream) :accessor resource)
+   (version :initform (make-string-output-stream) :accessor version))
+  (:default-initargs . (:state :read-http-method))
+  (:documentation "The request line parser FSM.
+When the machine arrives in the `:done' state the `http-method', `resource' and
+`version' slots are converted into strings."))
 
 (defun whitespace-p (code)
   "Is the `code' a code-char for a whitespace char?"
@@ -14,7 +17,7 @@
 
 (defstate request-fsm :read-http-method (fsm cc)
   (if (not (whitespace-p cc))
-      (not (setf (http-method fsm) (concatenate 'string (http-method fsm) (list (code-char cc)))))
+      (not (write-char (code-char cc) (http-method fsm)))
 
       (if (char-equal (code-char cc) #\Space)
           :read-resource
@@ -22,7 +25,7 @@
 
 (defstate request-fsm :read-resource (fsm cc)
   (if (not (whitespace-p cc))
-      (not (setf (resource fsm) (concatenate 'string (resource fsm) (list (code-char cc)))))
+      (not (write-char (code-char cc) (resource fsm)))
 
       (if (char-equal (code-char cc) #\Space)
           :read-version
@@ -30,7 +33,7 @@
 
 (defstate request-fsm :read-version (fsm cc)
   (if (not (whitespace-p cc))
-      (not (setf (version fsm) (concatenate 'string (version fsm) (list (code-char cc)))))
+      (not (write-char (code-char cc) (version fsm)))
 
       (if (char-equal (code-char cc) #\Return)
           :seek-newline
@@ -38,7 +41,10 @@
 
 (defstate request-fsm :seek-newline (fsm cc)
   (if (char-equal (code-char cc) #\Newline)
-      :done
+      (prog1 :done
+        (setf (http-method fsm) (get-output-stream-string (http-method fsm))
+              (resource fsm) (get-output-stream-string (resource fsm))
+              (version fsm) (get-output-stream-string (version fsm))))
       :error))
 
 ;;; Header block parser

--- a/src/methods.lisp
+++ b/src/methods.lisp
@@ -8,8 +8,6 @@
     (setf (queues hinge) (make-hash-table))
     (mapc #'(lambda (name-priority)
               (destructuring-bind (name . priority) name-priority
-                (format t "=> Making queue: ~S => ~S~%" name priority)
-
                 (setf (gethash name (queues hinge))
                       (make-instance 'running-queue :owner hinge :priority priority))))
           q-desc))


### PR DESCRIPTION
Instead of destructively updating strings with one byte updates in the HTTP request string and header parser state machines this patch uses `string-output-stream`s to accomplish the same task.

Through quick benchmarking, the method that was employed before was the slowest possible method to use to buffer string data one character at a time.

This also removes some noise that was being generated as part of the job scheduling API work.
