### PR TITLE
Update cffi git repository URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = git@github.com:sshirokov/cl-ev.git
 [submodule "vendor/cffi"]
 	path = vendor/cffi
-	url = git://common-lisp.net/projects/cffi/cffi.git
+	url = git://github.com/cffi/cffi.git
 [submodule "vendor/lisp-zmq"]
 	path = vendor/lisp-zmq
 	url = git://github.com/galdor/lisp-zmq.git


### PR DESCRIPTION
This fixes issue #15, so that hinge can be re-added to quicklisp
